### PR TITLE
Fix N/A score styling

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -263,10 +263,11 @@ button:disabled { opacity: 0.6; cursor: not-allowed; transform: none; box-shadow
 }
 .stat-value {
     font-size: 1.6rem; /* Leicht reduziert für Konsistenz und "N/A" */
-    font-weight: 700; 
+    font-weight: 700;
     color: var(--text-primary);
     line-height: 1.1; /* Engere Zeilenhöhe */
-    word-break: break-all; /* Stellt sicher, dass langer Text umbricht, obwohl N/A kurz ist */
+    word-break: break-word; /* Verhindert Überlaufen von kurzen Werten wie "N/A" */
+    overflow-wrap: anywhere;
 }
 /* Spezifische Anpassung für N/A, falls es immer noch Probleme gibt (optional) */
 /* .stat-value:contains("N/A") { font-size: 1.5rem; } /* CSS :contains ist nicht Standard, wäre JS Lösung */


### PR DESCRIPTION
## Summary
- prevent mean score "N/A" text from overflowing

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888ea2234e0832185e6478ac5119d8c